### PR TITLE
feat: Add label configs for all projects

### DIFF
--- a/sync-labels/configs/google/eme_logger.yaml
+++ b/sync-labels/configs/google/eme_logger.yaml
@@ -1,0 +1,6 @@
+# GitHub label config for eme_logger
+# These are the labels unique to the project.  See common.yaml for labels that
+# all projects share.
+
+
+- import: ../common/common.yaml

--- a/sync-labels/configs/joeyparrish/karma-local-wd-launcher.yaml
+++ b/sync-labels/configs/joeyparrish/karma-local-wd-launcher.yaml
@@ -1,0 +1,7 @@
+# GitHub label config for karma-local-wd-launcher
+# These are the labels unique to the project.  See common.yaml for labels that
+# all projects share.
+
+
+- import: ../common/common.yaml
+- import: ../common/browsers.yaml

--- a/sync-labels/configs/joeyparrish/shaka-github-tools.yaml
+++ b/sync-labels/configs/joeyparrish/shaka-github-tools.yaml
@@ -1,0 +1,6 @@
+# GitHub label config for shaka-github-tools
+# These are the labels unique to the project.  See common.yaml for labels that
+# all projects share.
+
+
+- import: ../common/common.yaml

--- a/sync-labels/configs/joeyparrish/trace-anything.yaml
+++ b/sync-labels/configs/joeyparrish/trace-anything.yaml
@@ -1,0 +1,7 @@
+# GitHub label config for trace-anything
+# These are the labels unique to the project.  See common.yaml for labels that
+# all projects share.
+
+
+- import: ../common/common.yaml
+- import: ../common/browsers.yaml

--- a/sync-labels/configs/joeyparrish/triage-party-config.yaml
+++ b/sync-labels/configs/joeyparrish/triage-party-config.yaml
@@ -1,0 +1,6 @@
+# GitHub label config for triage-party-config
+# These are the labels unique to the project.  See common.yaml for labels that
+# all projects share.
+
+
+- import: ../common/common.yaml

--- a/sync-labels/configs/joeyparrish/webdriver-installer.yaml
+++ b/sync-labels/configs/joeyparrish/webdriver-installer.yaml
@@ -1,0 +1,7 @@
+# GitHub label config for webdriver-installer
+# These are the labels unique to the project.  See common.yaml for labels that
+# all projects share.
+
+
+- import: ../common/common.yaml
+- import: ../common/browsers.yaml


### PR DESCRIPTION
Some projects had already had their labels synced before now.  This
adds configs for the remaining projects.