### PR TITLE
fix: Fix exception thrown by warning

### DIFF
--- a/update-issues/main.js
+++ b/update-issues/main.js
@@ -242,7 +242,7 @@ async function main() {
   milestones.sort(Milestone.compare);
   let nextMilestone = milestones[0];
   if (nextMilestone.version == null) {
-    core.warn('No version milestone found!  Using backlog instead.');
+    core.warning('No version milestone found!  Using backlog instead.');
     nextMilestone = backlog;
   }
 


### PR DESCRIPTION
The method is warning(), not warn().  I was looking at the logging API
of the wrong module when I wrote that.