### PR TITLE
ci: Update actions/checkout version

### DIFF
--- a/.github/workflows/sync-common-workflows.yaml
+++ b/.github/workflows/sync-common-workflows.yaml
@@ -42,7 +42,7 @@ jobs:
   sync-workflows:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: workflows
       - name: Sync Workflows

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: shaka-project/shaka-github-tools
 

--- a/.github/workflows/test-update-issues.yaml
+++ b/.github/workflows/test-update-issues.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 

--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: shaka-project/shaka-github-tools
 

--- a/sync-labels/sync-labels.yaml
+++ b/sync-labels/sync-labels.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: shaka-project/shaka-github-tools
 

--- a/update-issues/update-issues.yaml
+++ b/update-issues/update-issues.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: shaka-project/shaka-github-tools
 


### PR DESCRIPTION
v2 uses a deprecated node version (12), and v3 uses a current version (16).