### PR TITLE
feat(update-issues): Process PRs as well as issues

### DIFF
--- a/update-issues/issues.js
+++ b/update-issues/issues.js
@@ -307,6 +307,8 @@ class Issue extends GitHubObject {
     this.milestone = obj.milestone ? new Milestone(obj.milestone) : null;
     /** @type {boolean} */
     this.isPR = !!obj.pull_request;
+    /** @type {boolean} */
+    this.merged = obj.merged_at != null;
   }
 
   /**
@@ -527,7 +529,7 @@ class Issue extends GitHubObject {
         octokit.rest.issues.listForRepo, Issue, {
           state: 'all',
         });
-    return all.filter(issue => !issue.isPR);
+    return all;
   }
 }
 

--- a/update-issues/issues.js
+++ b/update-issues/issues.js
@@ -291,6 +291,8 @@ class Event extends GitHubObject {
   }
 }
 
+// Also could be a PR.  Both are returned by the GitHub issue API.
+// PRs have issue.isPR == true.
 class Issue extends GitHubObject {
   /** @param {!Object} obj */
   constructor(obj) {

--- a/update-issues/issues.js
+++ b/update-issues/issues.js
@@ -311,6 +311,9 @@ class Issue extends GitHubObject {
     this.isPR = !!obj.pull_request;
     /** @type {boolean} */
     this.merged = obj.merged_at != null;
+    /** @type {string} */
+    this.name =
+        (this.isPR ? 'PR #' : 'issue #') + this.number;
   }
 
   /**

--- a/update-issues/main.js
+++ b/update-issues/main.js
@@ -60,18 +60,22 @@ const PING_QUESTION_TEXT =
     'Does this answer all your questions? ' +
     'If so, would you please close the issue?';
 
-const CLOSE_STALE_TEXT =
+const CLOSE_STALE_ISSUE_TEXT =
     'Closing due to inactivity. If this is still an issue for you or if you ' +
     'have further questions, the OP can ask shaka-bot to reopen it by ' +
     'including `@shaka-bot reopen` in a comment.';
+
+const CLOSE_STALE_PR_TEXT =
+    'Closing due to inactivity. If the author would like to continue this ' +
+    'PR, they can reopen it (preferred) or start a new one (if needed).';
 
 const PING_INACTIVE_QUESTION_DAYS = 4;
 const CLOSE_AFTER_WAITING_DAYS = 7;
 const ARCHIVE_AFTER_CLOSED_DAYS = 60;
 
 
-async function archiveOldIssues(issue) {
-  // If the issue has been closed for a while, archive it.
+async function archiveOldIssuesAndPRs(issue) {
+  // If the issue or PR has been closed for a while, archive it.
   // Exclude locked issues, so that this doesn't conflict with unarchiveIssues
   // below.
   if (!issue.locked && issue.closed &&
@@ -81,17 +85,21 @@ async function archiveOldIssues(issue) {
   }
 }
 
-async function unarchiveIssues(issue) {
-  // If the archive label is removed from an archived issue, unarchive it.
+async function unarchiveIssuesAndPRs(issue) {
+  // If the archive label is removed from an archived issue or PR, unarchive it.
   if (issue.locked && !issue.hasLabel(STATUS_ARCHIVED)) {
     await issue.unlock();
-    await issue.reopen();
+    // If it's not a PR, reopen it.  Unlike issues, PRs cannot always be
+    // reopened automatically.
+    if (!issue.isPR) {
+      await issue.reopen();
+    }
   }
 }
 
 async function reopenIssues(issue) {
   // If the original author wants an issue reopened, reopen it.
-  if (issue.closed && !issue.hasLabel(STATUS_ARCHIVED)) {
+  if (!issue.isPR && issue.closed && !issue.hasLabel(STATUS_ARCHIVED)) {
     // Important: only load comments if prior filters pass!
     // If we loaded them on every issue, we could exceed our query quota!
     await issue.loadComments();
@@ -110,8 +118,8 @@ async function reopenIssues(issue) {
   }
 }
 
-async function manageWaitingIssues(issue) {
-  // Filter for waiting issues.
+async function manageWaitingIssuesAndPRs(issue) {
+  // Filter for waiting issues and PRs.
   if (!issue.closed && issue.hasLabel(STATUS_WAITING)) {
     const labelAgeInDays = await issue.getLabelAgeInDays(STATUS_WAITING);
 
@@ -129,14 +137,21 @@ async function manageWaitingIssues(issue) {
 
     // If an issue has been in a waiting state for too long, close it as stale.
     if (labelAgeInDays >= CLOSE_AFTER_WAITING_DAYS) {
-      await issue.postComment(CLOSE_STALE_TEXT);
+      // PRs and issues get slightly different messages because reopening them
+      // works differently.
+      if (issue.isPR) {
+        await issue.postComment(CLOSE_STALE_PR_TEXT);
+      } else {
+        await issue.postComment(CLOSE_STALE_ISSUE_TEXT);
+      }
+
       await issue.close();
     }
   }
 }
 
-async function cleanUpIssueTags(issue) {
-  // If an issue with the waiting tag was closed, remove the tag.
+async function cleanUpIssueAndPRTags(issue) {
+  // If an issue or PR with the waiting tag was closed, remove the tag.
   if (issue.closed && issue.hasLabel(STATUS_WAITING)) {
     await issue.removeLabel(STATUS_WAITING);
   }
@@ -144,7 +159,7 @@ async function cleanUpIssueTags(issue) {
 
 async function pingQuestions(issue) {
   // If a question hasn't been responded to recently, ping it.
-  if (!issue.closed &&
+  if (!issue.isPR && !issue.closed &&
       issue.hasLabel(TYPE_QUESTION) &&
       !issue.hasLabel(STATUS_WAITING)) {
     // Important: only load comments if prior filters pass!
@@ -165,9 +180,9 @@ async function pingQuestions(issue) {
   }
 }
 
-async function maintainMilestones(issue, nextMilestone, backlog) {
+async function maintainIssueMilestones(issue, nextMilestone, backlog) {
   // Set or remove milestones based on type labels.
-  if (!issue.closed) {
+  if (!issue.isPR && !issue.closed) {
     if (issue.hasAnyLabel(LABELS_FOR_NEXT_MILESTONE)) {
       if (!issue.milestone) {
         // Some (low) priority flags will indicate that an issue should go to
@@ -193,12 +208,12 @@ async function maintainMilestones(issue, nextMilestone, backlog) {
 
 const ALL_ISSUE_TASKS = [
   reopenIssues,
-  archiveOldIssues,
-  unarchiveIssues,
-  manageWaitingIssues,
-  cleanUpIssueTags,
+  archiveOldIssuesAndPRs,
+  unarchiveIssuesAndPRs,
+  manageWaitingIssuesAndPRs,
+  cleanUpIssueAndPRTags,
   pingQuestions,
-  maintainMilestones,
+  maintainIssueMilestones,
 ];
 
 async function processIssues(issues, nextMilestone, backlog) {

--- a/update-issues/main.js
+++ b/update-issues/main.js
@@ -110,7 +110,7 @@ async function reopenIssues(issue) {
           comment.ageInDays <= issue.closedDays &&
           body.includes('@shaka-bot') &&
           (body.includes('reopen') || body.includes('re-open'))) {
-        core.notice(`Found reopen request for issue #${issue.number}`);
+        core.notice(`Found reopen request for ${issue.name}`);
         await issue.reopen();
         break;
       }
@@ -223,11 +223,11 @@ async function processIssuesAndPRs(issues, nextMilestone, backlog) {
 
   for (const issue of issues) {
     if (issue.hasLabel(FLAG_IGNORE)) {
-      core.info(`Ignoring issue #${issue.number}`);
+      core.info(`Ignoring ${issue.name}`);
       continue;
     }
 
-    core.info(`Processing issue #${issue.number}`);
+    core.info(`Processing ${issue.name}`);
 
     for (const task of ALL_TASKS) {
       try {
@@ -236,7 +236,7 @@ async function processIssuesAndPRs(issues, nextMilestone, backlog) {
         // Make this show up in the Actions UI without needing to search the
         // logs.
         core.error(
-            `Failed to process issue #${issue.number} in task ${task.name}: ` +
+            `Failed to process ${issue.name} in task ${task.name}: ` +
             `${error}\n${error.stack}`);
         success = false;
       }

--- a/update-issues/main.js
+++ b/update-issues/main.js
@@ -206,7 +206,7 @@ async function maintainIssueMilestones(issue, nextMilestone, backlog) {
 }
 
 
-const ALL_ISSUE_TASKS = [
+const ALL_TASKS = [
   reopenIssues,
   archiveOldIssuesAndPRs,
   unarchiveIssuesAndPRs,
@@ -216,7 +216,9 @@ const ALL_ISSUE_TASKS = [
   maintainIssueMilestones,
 ];
 
-async function processIssues(issues, nextMilestone, backlog) {
+// Both issues and PRs are fetched by the issues API, and we now process both.
+// PRs have issue.isPR == true.
+async function processIssuesAndPRs(issues, nextMilestone, backlog) {
   let success = true;
 
   for (const issue of issues) {
@@ -227,7 +229,7 @@ async function processIssues(issues, nextMilestone, backlog) {
 
     core.info(`Processing issue #${issue.number}`);
 
-    for (const task of ALL_ISSUE_TASKS) {
+    for (const task of ALL_TASKS) {
       try {
         await task(issue, nextMilestone, backlog);
       } catch (error) {
@@ -261,7 +263,7 @@ async function main() {
     nextMilestone = backlog;
   }
 
-  const success = await processIssues(issues, nextMilestone, backlog);
+  const success = await processIssuesAndPRs(issues, nextMilestone, backlog);
   if (!success) {
     process.exit(1);
   }
@@ -273,7 +275,7 @@ if (require.main == module) {
   main();
 } else {
   module.exports = {
-    processIssues,
+    processIssuesAndPRs,
     TYPE_ACCESSIBILITY,
     TYPE_ANNOUNCEMENT,
     TYPE_BUG,

--- a/update-issues/mocks.js
+++ b/update-issues/mocks.js
@@ -122,6 +122,8 @@ class MockIssue extends MockGitHubObject {
       this.comments.push(new MockComment({body}));
     });
     this.loadComments = jasmine.createSpy('loadComments');
+    this.name =
+        (this.isPR ? 'PR #' : 'issue #') + this.number;
   }
 
   hasLabel(name) {

--- a/update-issues/mocks.js
+++ b/update-issues/mocks.js
@@ -74,6 +74,8 @@ class MockIssue extends MockGitHubObject {
       locked: false,
       milestone: null,
       comments: [],
+      isPR: false,
+      merged: false,
     };
 
     super(defaults, params);
@@ -83,32 +85,41 @@ class MockIssue extends MockGitHubObject {
             .and.returnValue(params.labelAgeInDays || 0);
     this.addLabel = jasmine.createSpy('addLabel').and.callFake((name) => {
       console.log(`Adding label ${name}`);
+      this.labels.push(name);
     });
     this.removeLabel = jasmine.createSpy('removeLabel').and.callFake((name) => {
       console.log(`Removing label ${name}`);
+      this.labels = this.labels.filter(l => l != name);
     });
     this.lock = jasmine.createSpy('lock').and.callFake(() => {
       console.log('Locking');
+      this.locked = true;
     });
     this.unlock = jasmine.createSpy('unlock').and.callFake(() => {
       console.log('Unlocking');
+      this.locked = false;
     });
     this.close = jasmine.createSpy('close').and.callFake(() => {
       console.log('Closing');
+      this.closed = true;
     });
     this.reopen = jasmine.createSpy('reopen').and.callFake(() => {
       console.log('Reopening');
+      this.closed = false;
     });
     this.setMilestone =
         jasmine.createSpy('setMilestone').and.callFake((milestone) => {
           console.log(`Setting milestone to "${milestone.title}"`);
+          this.milestone = milestone;
         });
     this.removeMilestone =
         jasmine.createSpy('removeMilestone').and.callFake(() => {
           console.log('Removing milestone.');
+          this.milestone = null;
         });
     this.postComment = jasmine.createSpy('postComment').and.callFake((body) => {
       console.log(`Posting comment: ${body}`);
+      this.comments.push(new MockComment({body}));
     });
     this.loadComments = jasmine.createSpy('loadComments');
   }

--- a/update-issues/tests.js
+++ b/update-issues/tests.js
@@ -87,7 +87,16 @@ describe('update-issues tool', () => {
     ageInDays: 0,
   });
 
-  it('archives old issues', async () => {
+  function reopenComment(author, ageInDays = 0) {
+    return new MockComment({
+      author,
+      ageInDays,
+      fromTeam: false,
+      body: '@shaka-bot reopen',
+    });
+  }
+
+  it('archives old issues and PRs', async () => {
     const matchingIssues = [
       new MockIssue({
         closed: true,
@@ -96,6 +105,11 @@ describe('update-issues tool', () => {
       new MockIssue({
         closed: true,
         closedDays: 100,
+      }),
+      new MockIssue({
+        closed: true,
+        closedDays: 100,
+        isPR: true,
       }),
       // This has the "archived" label, but is not locked.  It should still get
       // locked.
@@ -141,12 +155,17 @@ describe('update-issues tool', () => {
     }
   });
 
-  it('unarchives issues', async () => {
+  it('unarchives issues and PRs', async () => {
     const matchingIssues = [
       // Closed and locked, but the "archived" label has been removed.
       new MockIssue({
         closed: true,
         locked: true,
+      }),
+      new MockIssue({
+        closed: true,
+        locked: true,
+        isPR: true,
       }),
     ];
 
@@ -165,7 +184,11 @@ describe('update-issues tool', () => {
 
     for (const issue of matchingIssues) {
       expect(issue.unlock).toHaveBeenCalled();
-      expect(issue.reopen).toHaveBeenCalled();
+      if (issue.isPR) {
+        expect(issue.reopen).not.toHaveBeenCalled();
+      } else {
+        expect(issue.reopen).toHaveBeenCalled();
+      }
     }
     for (const issue of nonMatchingIssues) {
       expect(issue.unlock).not.toHaveBeenCalled();
@@ -176,7 +199,7 @@ describe('update-issues tool', () => {
     }
   });
 
-  it('removes "waiting" label', async () => {
+  it('removes "waiting" label from issues and PRs', async () => {
     const matchingIssues = [
       new MockIssue({
         labels: [STATUS_WAITING],
@@ -192,6 +215,13 @@ describe('update-issues tool', () => {
       new MockIssue({
         labels: [TYPE_BUG, STATUS_WAITING],
         labelAgeInDays: 1,
+        // Most recent comments go first.
+        comments: [externalCommentNew, teamCommentOld],
+      }),
+      new MockIssue({
+        labels: [TYPE_BUG, STATUS_WAITING],
+        labelAgeInDays: 1,
+        isPR: true,
         // Most recent comments go first.
         comments: [externalCommentNew, teamCommentOld],
       }),
@@ -223,7 +253,65 @@ describe('update-issues tool', () => {
     }
   });
 
-  it('closes stale issues', async () => {
+  it('reopens issues on OP request', async () => {
+    const matchingIssues = [
+      // A reopen request by the OP, and more recent than closure of the issue.
+      new MockIssue({
+        author: 'someone',
+        closed: true,
+        closedDays: 1,
+        comments: [reopenComment('someone', /* ageInDays */ 0)],
+      }),
+      // The reopen request need not be the most recent comment.
+      new MockIssue({
+        author: 'someone',
+        closed: true,
+        closedDays: 30,
+        // Most recent comments go first.
+        comments: [
+          externalCommentNew,
+          reopenComment('someone', /* ageInDays */ 10),
+        ],
+      }),
+    ];
+
+    const nonMatchingIssues = [
+      // No reopen request.
+      new MockIssue({
+        author: 'someone',
+        closed: true,
+        closedDays: 1,
+        comments: [],
+      }),
+      // A reopen request by the wrong user (not the OP).
+      new MockIssue({
+        author: 'someone',
+        closed: true,
+        closedDays: 1,
+        comments: [reopenComment('someoneElse', /* ageInDays */ 0)],
+      }),
+      // Closed again more recently than the last reopen request.
+      new MockIssue({
+        author: 'someone',
+        closed: true,
+        closedDays: 3,
+        comments: [reopenComment('someoneElse', /* ageInDays */ 20)],
+      }),
+    ];
+
+    const issues = matchingIssues.concat(nonMatchingIssues);
+
+    await processIssues(issues, nextMilestone, backlog);
+
+    for (const issue of matchingIssues) {
+      expect(issue.reopen).toHaveBeenCalled();
+    }
+    for (const issue of nonMatchingIssues) {
+      expect(issue.reopen).not.toHaveBeenCalled();
+    }
+  });
+
+  it('closes stale issues and PRs', async () => {
     const matchingIssues = [
       new MockIssue({
         labels: [STATUS_WAITING],
@@ -233,6 +321,11 @@ describe('update-issues tool', () => {
         labels: [STATUS_WAITING],
         labelAgeInDays: 100,
         comments: [teamCommentOld],
+      }),
+      new MockIssue({
+        labels: [STATUS_WAITING],
+        labelAgeInDays: 100,
+        isPR: true,
       }),
     ];
 
@@ -262,10 +355,15 @@ describe('update-issues tool', () => {
     }
   });
 
-  it('cleans up labels on closed issues', async () => {
+  it('cleans up labels on closed issues and PRs', async () => {
     const matchingIssues = [
       new MockIssue({
         closed: true,
+        labels: [STATUS_WAITING],
+      }),
+      new MockIssue({
+        closed: true,
+        isPR: true,
         labels: [STATUS_WAITING],
       }),
     ];
@@ -324,6 +422,13 @@ describe('update-issues tool', () => {
         // Most recent comments go first.
         comments: [externalCommentOld, teamCommentOld],
       }),
+      // Won't be touched because it's a PR.
+      new MockIssue({
+        closed: true,
+        isPR: true,
+        labels: [TYPE_QUESTION],
+        comments: [teamCommentOld],
+      }),
     ];
 
     const issues = matchingIssues.concat(nonMatchingIssues);
@@ -340,7 +445,7 @@ describe('update-issues tool', () => {
     }
   });
 
-  it('sets an appropriate milestone', async () => {
+  it('sets an appropriate milestone for issues', async () => {
     const nextMilestoneIssues = [
       // Bugs go to the next milestone.  (If the priority is P0-P2 or unset.)
       new MockIssue({
@@ -439,6 +544,11 @@ describe('update-issues tool', () => {
       new MockIssue({
         labels: [TYPE_ENHANCEMENT],
         closed: true,
+      }),
+      // Won't be assigned to a milestone because it's a PR.
+      new MockIssue({
+        labels: [TYPE_BUG],
+        isPR: true,
       }),
     ];
 

--- a/update-issues/tests.js
+++ b/update-issues/tests.js
@@ -33,7 +33,7 @@ const {
 } = require('./issues.js');
 
 const {
-  processIssues,
+  processIssuesAndPRs,
   TYPE_ACCESSIBILITY,
   TYPE_ANNOUNCEMENT,
   TYPE_BUG,
@@ -140,7 +140,7 @@ describe('update-issues tool', () => {
 
     const issues = matchingIssues.concat(nonMatchingIssues);
 
-    await processIssues(issues, nextMilestone, backlog);
+    await processIssuesAndPRs(issues, nextMilestone, backlog);
 
     for (const issue of matchingIssues) {
       expect(issue.addLabel).toHaveBeenCalledWith(STATUS_ARCHIVED);
@@ -180,7 +180,7 @@ describe('update-issues tool', () => {
 
     const issues = matchingIssues.concat(nonMatchingIssues);
 
-    await processIssues(issues, nextMilestone, backlog);
+    await processIssuesAndPRs(issues, nextMilestone, backlog);
 
     for (const issue of matchingIssues) {
       expect(issue.unlock).toHaveBeenCalled();
@@ -243,7 +243,7 @@ describe('update-issues tool', () => {
 
     const issues = matchingIssues.concat(nonMatchingIssues);
 
-    await processIssues(issues, nextMilestone, backlog);
+    await processIssuesAndPRs(issues, nextMilestone, backlog);
 
     for (const issue of matchingIssues) {
       expect(issue.removeLabel).toHaveBeenCalledWith(STATUS_WAITING);
@@ -301,7 +301,7 @@ describe('update-issues tool', () => {
 
     const issues = matchingIssues.concat(nonMatchingIssues);
 
-    await processIssues(issues, nextMilestone, backlog);
+    await processIssuesAndPRs(issues, nextMilestone, backlog);
 
     for (const issue of matchingIssues) {
       expect(issue.reopen).toHaveBeenCalled();
@@ -343,7 +343,7 @@ describe('update-issues tool', () => {
 
     const issues = matchingIssues.concat(nonMatchingIssues);
 
-    await processIssues(issues, nextMilestone, backlog);
+    await processIssuesAndPRs(issues, nextMilestone, backlog);
 
     for (const issue of matchingIssues) {
       expect(issue.postComment).toHaveBeenCalled();
@@ -376,7 +376,7 @@ describe('update-issues tool', () => {
 
     const issues = matchingIssues.concat(nonMatchingIssues);
 
-    await processIssues(issues, nextMilestone, backlog);
+    await processIssuesAndPRs(issues, nextMilestone, backlog);
 
     for (const issue of matchingIssues) {
       expect(issue.removeLabel).toHaveBeenCalledWith(STATUS_WAITING);
@@ -433,7 +433,7 @@ describe('update-issues tool', () => {
 
     const issues = matchingIssues.concat(nonMatchingIssues);
 
-    await processIssues(issues, nextMilestone, backlog);
+    await processIssuesAndPRs(issues, nextMilestone, backlog);
 
     for (const issue of matchingIssues) {
       expect(issue.postComment).toHaveBeenCalled();
@@ -557,7 +557,7 @@ describe('update-issues tool', () => {
         .concat(clearMilestoneIssues)
         .concat(nonMatchingIssues);
 
-    await processIssues(issues, nextMilestone, backlog);
+    await processIssuesAndPRs(issues, nextMilestone, backlog);
 
     for (const issue of nextMilestoneIssues) {
       expect(issue.setMilestone).toHaveBeenCalledWith(nextMilestone);


### PR DESCRIPTION
The Shaka Player maintainers list has discussed in the past the idea of processing PRs as well as issues with our automated tools.  I think it is particularly useful for managing stale PRs with the "waiting" tag.

Changes to processing:
 - Do not skip PRs at a high level
 - Archive PRs with the same rules used for issues
 - Unarchive PRs with the same rules used for issues, except that PRs won't be automatically reopened
 - Close stale PRs with the same rules as issues, but with a different message (since PRs can't be automatically reopened in many cases)
 - Clean up "waiting" tags from closed PRs (same as issues)
 - Clean up "waiting" tags from PRs after a new comment (same as issues)

PRs are excluded from these issue processing features:
 - Reopen issue by specially-formatted OP comment, since PRs can't be automatically reopened in many cases
 - Any rules for issues with the "question" tag, which wouldn't make sense for PRs
 - Automatic milestone management

Changes to tests:
 - Set defaults for isPR, merged in mocks
 - Maintain basic state in mock methods (fixes several pre-existing test failures)
 - Add PR scenarios to test cases
 - Add missing test cases for pre-existing reopen features