### PR TITLE
fix: Fix workflow permissions to update PRs

### DIFF
--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   update-issues:

--- a/update-issues/update-issues.yaml
+++ b/update-issues/update-issues.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   update-issues:


### PR DESCRIPTION
The changes to the update-issues tool to process PRs failed due to permission errors.  This adds necessary permissions to the workflow.