### PR TITLE
feat(update-issues): Use shaka-bot token

### DIFF
--- a/update-issues/update-issues.yaml
+++ b/update-issues/update-issues.yaml
@@ -23,7 +23,8 @@ jobs:
 
       - name: Update Issues
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use SHAKA_BOT_TOKEN if found, otherwise the default GITHUB_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.SHAKA_BOT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           cd update-issues
           npm ci


### PR DESCRIPTION
If the SHAKA_BOT_TOKEN secret is not found, we will fall back to the default GITHUB_TOKEN.