### PR TITLE
feat: Migrate set-commit-status action from shaka-player

### DIFF
--- a/set-commit-status/README.md
+++ b/set-commit-status/README.md
@@ -1,0 +1,19 @@
+# Set Commit Status
+
+A reusable action that sets the commit status.  This is used to set PR status
+from workflows with non-PR triggers (such as manually-triggered workflows).
+
+To use this in a step, write something like:
+
+```yaml
+      - name: Report final commit status
+        # Will run on success or failure, but not if the workflow is cancelled
+        # or if we were asked to ignore the test status.
+        if: ${{ (success() || failure()) && inputs.skip_commit_status == false }}
+        uses: shaka-project/shaka-github-tools/set-commit-status
+        with:
+          context: Example Check / ${{ matrix.some_parameter }}
+          job_name: Optional Job Name for Deep Linking from Status
+          state: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/set-commit-status/action.yaml
+++ b/set-commit-status/action.yaml
@@ -1,0 +1,74 @@
+# Migrated from shaka-project/shaka-player/.github/workflows/custom-actions
+#
+# To use this in a step, write something like:
+#
+#      - name: Report final commit status
+#        # Will run on success or failure, but not if the workflow is cancelled
+#        # or if we were asked to ignore the test status.
+#        if: ${{ (success() || failure()) && inputs.skip_commit_status == false }}
+#        uses: shaka-project/shaka-github-tools/set-commit-status
+#        with:
+#          context: Example Check / ${{ matrix.some_parameter }}
+#          job_name: Optional Job Name for Deep Linking from Status
+#          state: ${{ job.status }}
+#          token: ${{ secrets.GITHUB_TOKEN }}
+
+name: Set Commit Status
+
+description: |
+  A reusable action that sets the commit status.  This is used to set PR status
+  from workflows with non-PR triggers (such as manually-triggered workflows).
+
+inputs:
+  context:
+    description: An arbitrary string to identify the status check.
+    required: true
+  state:
+    description: Either "pending", "error", "success", or "failure".
+    required: true
+  token:
+    description: A GitHub access token.
+    required: true
+  job_name:
+    description: A job name, so that the status' target URL can point to a specific job.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Report Commit Status
+      shell: bash
+      run: |
+        export GITHUB_TOKEN="${{ inputs.token }}"
+
+        # Here we compute a "target URL".  It will be attached to the commit
+        # status, so that when someone clicks "details" next to the status on
+        # the PR, it will link to the appropriate logs.
+        if [[ "${{ inputs.job_name }}" != "" ]]; then
+          # There are three identifiers for the job:
+          #   - The job's key in YAML, which is "github.job"
+          #   - The job's name, which is not provided by any runner environment
+          #   - The job's numerical ID, which is not provided either
+          # To link to this specific job in the status, we need the numerical
+          # job ID.  The GH API provides a list of jobs, which contain
+          # numerical IDs and names, but not keys.  So the caller of this
+          # action must provide the string name, and then we look up the
+          # numerical ID in the API.  "github.job" is useless here.
+          job_id=$(
+            gh api /repos/${{github.repository}}/actions/runs/${{github.run_id}}/jobs \
+                | jq '.jobs | map(select(.name=="${{ inputs.job_name }}")) | .[].id'
+          )
+          TARGET_URL="https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}/job/$job_id"
+        else
+          # Generic link to the run, without any specific job.
+          TARGET_URL="https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}"
+        fi
+
+        SHA1=$(git rev-parse HEAD)
+
+        gh api \
+          -X POST \
+          -F "context=${{ inputs.context }}" \
+          -F "state=${{ inputs.state }}" \
+          -F "target_url=$TARGET_URL" \
+          "repos/${{ github.repository }}/statuses/$SHA1"


### PR DESCRIPTION
This makes the action reusable and independent of Shaka Player and its forks / PRs.