### PR TITLE
ci: Do not persist credentials after checkout

### DIFF
--- a/.github/workflows/sync-common-workflows.yaml
+++ b/.github/workflows/sync-common-workflows.yaml
@@ -45,6 +45,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: workflows
+          persist-credentials: false
+
       - name: Sync Workflows
         run: |
           git config --global user.email "shaka-bot@users.noreply.github.com"

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: shaka-project/shaka-github-tools
+          persist-credentials: false
 
       # TODO: revert to micnncim and new release after landing
       #       https://github.com/micnncim/action-label-syncer/pull/68

--- a/.github/workflows/test-update-issues.yaml
+++ b/.github/workflows/test-update-issues.yaml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Test
         run: |

--- a/.github/workflows/update-issues.yaml
+++ b/.github/workflows/update-issues.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: shaka-project/shaka-github-tools
+          persist-credentials: false
 
       - name: Update Issues
         env:

--- a/compute-sha/README.md
+++ b/compute-sha/README.md
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.compute-sha.outputs.SHA }}
+          persist-credentials: false
 
       # ...
 ```

--- a/sync-labels/sync-labels.yaml
+++ b/sync-labels/sync-labels.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: shaka-project/shaka-github-tools
+          persist-credentials: false
 
       # TODO: revert to micnncim and new release after landing
       #       https://github.com/micnncim/action-label-syncer/pull/68

--- a/update-issues/update-issues.yaml
+++ b/update-issues/update-issues.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: shaka-project/shaka-github-tools
+          persist-credentials: false
 
       - name: Update Issues
         env:


### PR DESCRIPTION
See actions/checkout#485 and https://johnstawinski.com/2024/01/11/playing-with-fire-how-we-executed-a-critical-supply-chain-attack-on-pytorch/

In short, it is a terrible idea to persist even our default credentials after checkout. There's no call for that, so we will now set `persist-credentials: false` on all checkout actions.