### PR TITLE
feat: Sync common policy documents across repositories

### DIFF
--- a/.github/workflows/sync-policies.json
+++ b/.github/workflows/sync-policies.json
@@ -1,0 +1,24 @@
+{
+  "comment1": "These repos release from main, and only the latest release is supported.",
+  "repos-with-no-branches": [
+    "shaka-project/eme-encryption-scheme-polyfill",
+    "shaka-project/eme_logger",
+    "shaka-project/express-chocolatey-server",
+    "shaka-project/generic-webdriver-server",
+    "shaka-project/karma-local-wd-launcher",
+    "shaka-project/shaka-github-tools",
+    "shaka-project/shaka-lab",
+    "shaka-project/shaka-packager",
+    "shaka-project/shaka-player-history",
+    "shaka-project/shaka-project.github.io",
+    "shaka-project/shaka-streamer",
+    "shaka-project/static-ffmpeg-binaries",
+    "shaka-project/trace-anything",
+    "shaka-project/triage-party-config",
+    "shaka-project/webdriver-installer"
+  ],
+  "comment2": "These repos have certain maintained branches, and get a specialized SECURITY.md with reference to branch maintenance policies.",
+  "repos-with-release-branches": [
+    "shaka-project/shaka-player"
+  ]
+}

--- a/.github/workflows/sync-policies.yaml
+++ b/.github/workflows/sync-policies.yaml
@@ -1,0 +1,174 @@
+name: Sync Policy Documents
+
+# Sync common policy documents across repos.  If a document changes here,
+# this will create a PR in each of our other repos to update their copies of
+# these documents.
+#
+# The token used by this workflow (SHAKA_BOT_PR_TOKEN) is associated with the
+# "shaka-bot" account.
+
+on:
+  workflow_dispatch:
+    # Allows for manual triggering.
+    inputs:
+      repos:
+        type: string
+        description: A space-separated list of repos to push to.
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/sync-policies.json
+      - policies/
+
+env:
+  CONFIG: .github/workflows/sync-policies.json
+  PR_BRANCH: sync-policies
+
+jobs:
+  sync-policies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: tools-repo
+          persist-credentials: false
+
+      - name: Sync Policies
+        run: |
+          git config --global user.email "shaka-bot@users.noreply.github.com"
+          git config --global user.name "Shaka Bot"
+          echo "${{ secrets.SHAKA_BOT_PR_TOKEN }}" | gh auth login --with-token
+
+          REPO_NO_BRANCHES_LIST=$(cat tools-repo/$CONFIG | jq -r '."repos-with-no-branches"[]')
+          REPO_WITH_BRANCHES_LIST=$(cat tools-repo/$CONFIG | jq -r '."repos-with-release-branches"[]')
+
+          POLICY_DOC_LIST=$(cd tools-repo/policies; ls)
+
+          # The security doc contains variants of certain sections.  Create two
+          # versions of the doc in memory now, with only one variant of these
+          # sections included.
+          SECURITY_MD_NO_BRANCHES=""
+          SECURITY_MD_WITH_BRANCHES=""
+          COMMON=1
+          BRANCHES=0
+          NEWLINE=$'\n'
+          # The end of this loop has an input redirection to read SECURITY.md.
+          # This structure is important because it does not create a subshell.
+          # A subshell would keep us from changing the variables on the outside
+          # of the loop.  Using IFS= here tells bash to preserve all whitespace
+          # in the line, and not to treat the input as delimited tokens.
+          while IFS= read line; do
+            # This is the start of a section only included for repos with branches.
+            if echo "$line" | grep -q '^## .* (with-branches)'; then
+              COMMON=0
+              BRANCHES=1
+              line=$(echo "$line" | sed -e 's/ (with-branches)//')
+            # This is the start of a section only included for repos without branches.
+            elif echo "$line" | grep -q '^## .* (no-branches)'; then
+              COMMON=0
+              BRANCHES=0
+              line=$(echo "$line" | sed -e 's/ (no-branches)//')
+            # This is the start of a section common to every repo.
+            elif echo "$line" | grep -q '^## '; then
+              COMMON=1
+            fi
+
+            # Add the current line to one doc, or to both, as appropriate,
+            # based on the state from the parser above.
+            if [[ $COMMON == 1 ]]; then
+              SECURITY_MD_WITH_BRANCHES="${SECURITY_MD_WITH_BRANCHES}${line}${NEWLINE}"
+              SECURITY_MD_NO_BRANCHES="${SECURITY_MD_NO_BRANCHES}${line}${NEWLINE}"
+            elif [[ $BRANCHES == 1 ]]; then
+              SECURITY_MD_WITH_BRANCHES="${SECURITY_MD_WITH_BRANCHES}${line}${NEWLINE}"
+            else
+              SECURITY_MD_NO_BRANCHES="${SECURITY_MD_NO_BRANCHES}${line}${NEWLINE}"
+            fi
+          done < tools-repo/policies/SECURITY.md
+
+          for REPO in $REPO_NO_BRANCHES_LIST $REPO_WITH_BRANCHES_LIST; do
+            if echo "$REPO_WITH_BRANCHES_LIST" | grep -q "^$REPO\$"; then
+              WITH_BRANCHES=1
+            else
+              WITH_BRANCHES=0
+            fi
+            echo ""
+            echo "Working on $REPO, WITH_BRANCHES=$WITH_BRANCHES..."
+
+            # Fork each repo under shaka-bot if we haven't yet.
+            gh repo fork "$REPO" --clone=false
+            # Some messages from "gh repo fork" don't end in a newline.
+            # Add a newline to clean up the logs.
+            echo ""
+
+            # Pause between forking and cloning.  This seems to fix errors that
+            # occur when trying to clone in one step or trying to fork and then
+            # immediately clone.
+            sleep 5
+
+            # Clone each forked repo.
+            FORK="shaka-bot/$(basename $REPO)"
+            git clone "https://${{ secrets.SHAKA_BOT_PR_TOKEN }}@github.com/$FORK"
+
+            # Use a subshell to change directories.  The working directory will
+            # revert when the subshell ends, so each loop starts from the same
+            # place.
+            (
+              cd $(basename "$REPO")
+
+              # Add the upstream remote and update it.
+              git remote add upstream https://github.com/$REPO
+              git fetch upstream
+
+              # Create a local branch for a potential PR.  Start at main.
+              git checkout -b "$PR_BRANCH" upstream/main
+
+              # Update every doc, creating those that don't already exist.
+              for DOC in $POLICY_DOC_LIST; do
+                if [[ "$DOC" == "SECURITY.md" ]]; then
+                  # SECURITY.md is special, with a customized version for
+                  # different categories of repo.
+                  if [[ $WITH_BRANCHES == 1 ]]; then
+                    echo "$SECURITY_MD_WITH_BRANCHES" > SECURITY.md
+                  else
+                    echo "$SECURITY_MD_NO_BRANCHES" > SECURITY.md
+                  fi
+                else
+                  # All other docs are simple.  Just copy them.
+                  cp "../tools-repo/policies/$DOC" .
+                fi
+
+                git add "$DOC"
+                echo "Syncing $DOC in $REPO"
+              done
+
+              # If anything has changed, generate a commit in a PR branch.
+              if ! git diff --cached --quiet; then
+                echo "chore: Sync policy documents" > .sync-pr-title
+
+                echo "This is an automated sync of policy documents for this organization." > .sync-pr-body
+                echo "The upstream source is:" >> .sync-pr-body
+                echo "https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA" >> .sync-pr-body
+
+                (cat .sync-pr-title; echo; cat .sync-pr-body) > .sync-pr-message
+                git commit -F .sync-pr-message
+                git push -f origin "HEAD:$PR_BRANCH"
+                echo "Pushed to branch in $REPO"
+
+                # If there's not an open PR from that branch, create one.
+                PR_URL=$(gh pr list -H "$PR_BRANCH" --json url | jq -r first.url)
+                if [[ "$PR_URL" == "null" ]]; then
+                  gh pr create \
+                      --title "$(cat .sync-pr-title)" \
+                      --body-file .sync-pr-body \
+                      --head shaka-bot:$PR_BRANCH
+                  echo "Created PR in $REPO"
+                else
+                  gh pr edit "$PR_URL" --body-file .sync-pr-body
+                  echo "Updated PR body in $REPO"
+                fi
+              else
+                echo "No changes in $REPO"
+              fi
+            )
+          done

--- a/policies/CODE_OF_CONDUCT.md
+++ b/policies/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+*shaka-player-maintainers@googlegroups.com*. If for any reason, you are
+uncomfortable reaching out to the community leaders, please email
+*opensource@google.com*.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/policies/SECURITY.md
+++ b/policies/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions (with-branches)
+
+ * This repository currently maintains release branches.  **Only certain branches are supported and maintained.**  For details on maintained branches, see [maintained-branches.md][].
+
+ * If a security issue is identified in a maintained branch, the fix will be made in `main`, then cherry-picked to all active release branches.
+
+ * If a security issue is identified in any release, we will disclose the issue and advise everyone to upgrade to one of the fixed versions.
+
+
+## Supported Versions (no-branches)
+
+ * This repository does not currently maintain release branches.  **Only the latest release is supported.**
+
+ * If a security issue is identified in a current release, the fix will trigger a new release from `main`.
+
+ * If a security issue is identified in any release, we will disclose the issue and advise everyone to upgrade to the latest release.
+
+
+## Reporting a Vulnerability
+
+Per Google policy, please use https://g.co/vulnz to report security vulnerabilities.  Google uses this for intake and triage.  For valid issues, we will do coordination and disclosure here on GitHub (including using a GitHub Security Advisory when necessary).
+
+The Google Security Team will process your report within a day, and respond within a week (although it will depend on the severity of your report).
+
+
+## Remediation Actions
+
+ * A GitHub issue will be created with the `type: vulnerability` label to coordinate a response.  After remediation, we will also use this issue to disclose any details we withheld between receiving the private report and resolving the issue.
+
+ * A GitHub Security Advisory may be created, if appropriate.  For example, this would be done if the issue impacts users or dependent projects.  This might be skipped for other issues, such as CI workflow vulnerabilities.
+
+ * Vulnerabilities in NPM modules will be reported to NPM so that they show up in `npm audit`.
+


### PR DESCRIPTION
Every repository under shaka-project will now get synchronized policy documents like SECURITY.md and CODE_OF_CONDUCT.md.  They will be centrally maintained here, as we do for certain common workflows.

SECURITY.md gets special parsing, choosing exactly one version of the "Supported Versions" section.

SECURITY.md is based on Google's standard vulnerability-reporting boilerplate, merged into GitHub's suggested boilerplate, and customized with details relevant to our projects.  None of our projects had a SECURITY.md file before now.

CODE_OF_CONDUCT.md is based on version 2.1 of the Contributor Covenant.  This replaces version 1.4 of the same that was already in use in some (but not all) projects.